### PR TITLE
Insulated Horshoe Crafting

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -653,3 +653,18 @@
 		/obj/item/clothing/mask/gas/clown_hat = 1,
 	)
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/insulated_horseshoes
+	name = "Insulated Horseshoes"
+	result = /obj/item/clothing/shoes/horseshoes
+	time = 6 SECONDS
+	tool_behaviors = list(TOOL_WIRECUTTER)
+	reqs = list(
+		/obj/item/clothing/gloves = 1,
+		/obj/item/stack/sheet/iron = 5,
+	)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/insulated_horseshoes/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/clothing/gloves/insulated = collected_requirements[/obj/item/clothing/gloves][1]
+	return insulated.siemens_coefficient == 0 // gloves are not subtyped, so a special check is required to make sure they are insulated

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1348,6 +1348,9 @@
 
 /// Returns if the carbon is wearing shock proof gloves
 /mob/living/carbon/proc/wearing_shock_proof_gloves()
+	if (HAS_TRAIT(src, TRAIT_PONY_PREFS))
+		return shoes?.siemens_coefficient == 0
+
 	return gloves?.siemens_coefficient == 0
 
 /// Modifies max_skillchip_count and updates active skillchips


### PR DESCRIPTION
Adds the ability to craft insulated horseshoes with 5 iron, a wirecutter, and any insulated gloves
:cl:
add: insulated glove crafting
fix: insulated horseshoes not counting as true insulation
:cl:
